### PR TITLE
Updated version # on DockerHub image

### DIFF
--- a/.github/workflows/main_sharing-pictures.yml
+++ b/.github/workflows/main_sharing-pictures.yml
@@ -37,10 +37,10 @@ jobs:
       run: docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     
     - name: Build Docker image
-      run: docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ub-es-2023-b3:3.0 .
+      run: docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/ub-es-2023-b3:4.0 .
       
     - name: Tag Docker image
-      run: docker tag ${{ secrets.DOCKER_HUB_USERNAME }}/ub-es-2023-b3:3.0 ${{ secrets.DOCKER_HUB_USERNAME }}/ub-es-2023-b3:3.0
+      run: docker tag ${{ secrets.DOCKER_HUB_USERNAME }}/ub-es-2023-b3:4.0 ${{ secrets.DOCKER_HUB_USERNAME }}/ub-es-2023-b3:4.0
    
     - name: Push Docker image
-      run: docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ub-es-2023-b3:3.0
+      run: docker push ${{ secrets.DOCKER_HUB_USERNAME }}/ub-es-2023-b3:4.0


### PR DESCRIPTION
Just updated DockerHub image in order to be able to save a new sprint image without overdriving past one.